### PR TITLE
Add Dockerfile for convenience

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,11 @@
+# If this is the first time you are running it, do the following in the project root.
+# docker build -t <image_name> ./
+# docker run -it --gpus all -p <port>:8888 -v ${pwd}:/tf/<folder_name> --name <container_name> <image_name>
+# (Windows: ${pwd}, Ubuntu: `pwd`)
+
+# When you use 'start' command to wake up the container, run jupyter with
+# source /etc/bash.bashrc && jupyter notebook --notebook-dir=/tf --ip 0.0.0.0 --no-browser --allow-root
+
 FROM tensorflow/tensorflow:2.5.0-gpu-jupyter
 
 LABEL maintainer="KawaSwitch <bb52120306@ms.nagasaki-u.ac.jp"
@@ -9,15 +17,3 @@ RUN apt-get update && \
     libgl1-mesa-dev 
 
 RUN pip install opencv-python opencv-contrib-python
-
-# WORKDIR /app
-# ADD ./requirements.txt /app
-
-# pip install -r
-# opencv-python opencv-contrib-python
-
-#CMD [ "executable" ]
-
-
-# Run with
-# docker run -it --gpus all -p <port>:8888 -v ${pwd}:/tf/<folder_name> --name tensor_origin tensorflow/tensorflow:2.5.0-gpu-jupyter

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM tensorflow/tensorflow:2.5.0-gpu-jupyter
+
+LABEL maintainer="KawaSwitch <bb52120306@ms.nagasaki-u.ac.jp"
+LABEL description="Image for the study of DCGAN with tensorflow 2.5.0"
+LABEL version="1.0"
+
+RUN apt-get update && \
+    apt-get install -y \
+    libgl1-mesa-dev 
+
+RUN pip install opencv-python opencv-contrib-python
+
+# WORKDIR /app
+# ADD ./requirements.txt /app
+
+# pip install -r
+# opencv-python opencv-contrib-python
+
+#CMD [ "executable" ]
+
+
+# Run with
+# docker run -it --gpus all -p <port>:8888 -v ${pwd}:/tf/<folder_name> --name tensor_origin tensorflow/tensorflow:2.5.0-gpu-jupyter


### PR DESCRIPTION
## 実装概要
* practice.pyが実行できるDockerfileを追加
WIndows 11(on Docker Desktop / WSL 2 backend)で実行確認
Windowsで実行する際には, ファイルシステムの違いの吸収によるパフォーマンスの大幅低下が知られているらしく, WSL 2側にプロジェクトのディレクトリを作成し, ボリュームをマウントする必要があった.
[参照元: Best practice](https://docs.docker.com/docker-for-windows/wsl/)

## 懸念点 / 課題
* requirements.txt使ってpipしてない → 今のところ2つしかないので良いが増えてきたら検討
* 実行に必要なフォルダの生成を行っていない → pythonの方で実行すべき